### PR TITLE
Fix commit

### DIFF
--- a/lib/gitcycle.rb
+++ b/lib/gitcycle.rb
@@ -175,7 +175,7 @@ class Gitcycle
       id = branch["lighthouse_url"].match(/tickets\/(\d+)/)[1] rescue nil
 
       if branch && id
-        msg = "[#{id}]"
+        msg = "[##{id}]"
         msg += " #{branch["title"]}" if branch["title"]
       end
     end


### PR DESCRIPTION
Ticket number lacked preceding "#".

This is necessary for lighthouse to identify commits.
