### PR TITLE
make branch-to-merge-into red instead of letting it blend in

### DIFF
--- a/lib/gitcycle/branch.rb
+++ b/lib/gitcycle/branch.rb
@@ -29,7 +29,7 @@ class Gitcycle
         exec_git(:branch, args)
       end
 
-      unless yes?("\nYour work will eventually merge into '#{params['branch[source]']}'. Is this correct?")
+      unless yes?("\nYour work will eventually merge into '#{params['branch[source]'].red}'. Is this correct?")
         params['branch[source]'] = q("What branch would you like to eventually merge into?")
       end
 


### PR DESCRIPTION
Should help you notice it more.

However I'm guessing this won't actually work, because `yes?` uses `q` which will stick a `.yellow` onto anything it gets...
